### PR TITLE
Add timezone detection for correct cron scheduling

### DIFF
--- a/esphome/components/dynamic_cron/__init__.py
+++ b/esphome/components/dynamic_cron/__init__.py
@@ -1,9 +1,14 @@
 from time import time
+import logging
 import yaml
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch, text, text_sensor
+from esphome.components.time import detect_tz
 from esphome.helpers import sanitize, snake_case
+
+_LOGGER = logging.getLogger(__name__)
+
 from esphome.const import (
                       CONF_ID,
                       CONF_LAMBDA,
@@ -151,6 +156,17 @@ async def to_code(config):
     cg.add(var.setCrontabDefault(config[CONF_CRONTAB]))
     cg.add(var.setClearPrefs(config[CONF_CLEAR_PREFS]))
     cg.add(var.setTimeFormatDefault(config[CONF_TIME_FORMAT]))
+
+    # Auto-detect POSIX TZ string so libc localtime/mktime (used by croncpp) are correct.
+    try:
+        tz_str = detect_tz()
+        _LOGGER.info("dynamic_cron: auto-detected timezone '%s'", tz_str)
+        cg.add(var.setTimezone(tz_str))
+    except cv.Invalid:
+        _LOGGER.warning(
+            "dynamic_cron: could not auto-detect timezone. "
+            "Scheduling may use wrong time offset."
+        )
     
     
     ###  ESPHome Entities/Controls/Display  ###

--- a/esphome/components/dynamic_cron/dynamic_cron_esphome.h
+++ b/esphome/components/dynamic_cron/dynamic_cron_esphome.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string>
 #include <ctime>
+#include <cstdlib>
 
 #include "esphome/core/component.h"
 #include "esphome/core/application.h"
@@ -74,6 +75,10 @@ protected:
 
   bool                                 setup_complete;
 
+  // POSIX TZ string for libc timezone sync (needed by croncpp).
+  std::string                          timezone_str_;
+  bool                                 timezone_applied_{false};
+
 public:
   double                               cron_loop_interval; // seconds
   //double                              save_prefs_interval; // seconds
@@ -126,6 +131,14 @@ public:
 
   // Esphome Component overrides
   void setup() override {
+
+    // Sync libc timezone so localtime()/mktime() (used by croncpp) are correct.
+    if (!timezone_applied_ && !timezone_str_.empty()) {
+      setenv("TZ", timezone_str_.c_str(), 1);
+      tzset();
+      timezone_applied_ = true;
+      LOGI("Applied POSIX timezone: %s", timezone_str_.c_str());
+    }
 
     if (!version_logged) {
       printVersion();
@@ -243,6 +256,10 @@ public:
   void setClearPrefs(bool val) {
     clear_prefs = val;
   }
+
+  void setTimezone(const std::string &tz) {
+    timezone_str_ = tz;
+  }
   
   
   // Overides base setters to include preference storage.
@@ -301,6 +318,8 @@ protected:
   //       them if necessary for debugging.
   //
   bool timeIsValid(std::time_t now = std::time(NULL)) {
+    if (!timezone_applied_) return false;
+
     //LOGV("Schedule::timeIsValid() calling ESPTime::from_epoch_local()");
     ESPTime esp_time = ESPTime::from_epoch_local(now);
 


### PR DESCRIPTION
## Add timezone detection for correct cron scheduling

### Problem

On Arduino/ESP32, the C library's `localtime()` and `mktime()` functions default to UTC because `setenv("TZ", ...)` is never called (ESPHome only sets the timezone for ESP-IDF, not Arduino). Since croncpp relies on these libc functions internally, all cron schedule calculations were offset by the local timezone difference (e.g. +2 hours for `Europe/Vienna` in CEST).

### Solution

- Auto-detect the POSIX timezone string at build time using ESPHome's existing `detect_tz()` function
- Pass it into the `Schedule` component via a new `setTimezone()` method
- Call `setenv("TZ", ...) / tzset()` at boot in `setup()` before any time calculations
- Gate `timeIsValid()` on `timezone_applied_` to prevent cronnext from being computed against UTC before the timezone is set

### Changes

- **`dynamic_cron_esphome.h`**: Added `timezone_str_` / `timezone_applied_` members, `setTimezone()` setter, `setenv`/`tzset` call in `setup()`, timezone gate in `timeIsValid()`
- **`__init__.py`**: Added `detect_tz()` call in `to_code()` to auto-detect and inject the POSIX TZ string at build time

### Notes

- No configuration changes required — timezone is auto-detected from ESPHome's `time` component
- Backward compatible — no changes to YAML schema
- Only 2 files changed, 35 lines added